### PR TITLE
Hide download CV button on home page

### DIFF
--- a/portfolio_pj/portfolio_app/template/index.html
+++ b/portfolio_pj/portfolio_app/template/index.html
@@ -62,7 +62,6 @@
 						<p>Today my focus centres on AI and automation. I design custom integrations and intelligent workflows that eliminate manual effort, accelerate team output, and create measurable efficiency gains &mdash; bridging the gap between cutting-edge technology and real business value.</p>
 						<!-- about buttons start -->
 						<div class="about-buttons">
-							<a target="_blank" href="https://1drv.ms/b/c/383EFE1C5687C4BF/IQCrTYmyTl_bQa05CKfsn8ZlAcl9dLKxP__0XwS_VA3nddM?e=dItis7" class="bordered-btn">download cv <i class="flaticon-download"></i></a>
 							<a href="https://www.upwork.com/fl/duynb" class="filled-btn smooth">hire me <i class="flaticon-mail"></i></a>
 						</div>
 						<!-- about buttons end -->


### PR DESCRIPTION
## Summary
- Removes the download CV button from the about section on the home page

## Test plan
- [ ] Verify the home page no longer shows the download CV button
- [ ] Verify the "hire me" button still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)